### PR TITLE
Add confirmation prompt when posting highlighted text

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { App, Editor, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
 import { createBlueskyPost } from '@/bluesky';
+import { ConfirmPostModal } from '@/modals/ConfirmPostModal';
 import { BlueskyTab } from '@/views/BlueskyTab';
 import { BLUESKY_TITLE, VIEW_TYPE_TAB } from '@/consts';
 import { setIcon } from "obsidian";
@@ -8,12 +9,14 @@ interface BlueskyPluginSettings {
     blueskyIdentifier: string;
     blueskyAppPassword: string;
     postArchiveFolder: string;
+    confirmBeforePosting: boolean;
 }
 
 const INITIAL_BLUESKY_SETTINGS: BlueskyPluginSettings = {
     blueskyIdentifier: '',
     blueskyAppPassword: '',
-    postArchiveFolder: ''
+    postArchiveFolder: '',
+    confirmBeforePosting: true
 }
 
 export default class BlueskyPlugin extends Plugin {
@@ -43,16 +46,12 @@ export default class BlueskyPlugin extends Plugin {
                     return;
                 }
 
-                try {
-                    await createBlueskyPost(this, selectedText);
-                } catch (error) {
-                    if (error.message.includes('Failed to fetch')) {
-                        new Notice('Failed to post. Could not connect to the internet.')
-                      } else if (error.message.includes('Invalid identifier or password')) {
-                        new Notice('Invalid bluesky handle or password. Please check your bluesky plugin settings.')
-                      } else {
-                        new Notice(`Failed to post: ${error.message}`);
-                      }
+                if (this.settings.confirmBeforePosting) {
+                    new ConfirmPostModal(this.app, selectedText, () => {
+                        this.postHighlightedText(selectedText);
+                    }).open();
+                } else {
+                    await this.postHighlightedText(selectedText);
                 }
             }
         });
@@ -73,6 +72,20 @@ export default class BlueskyPlugin extends Plugin {
         });
 
         this.addSettingTab(new BlueskySettingTab(this.app, this));
+    }
+
+    async postHighlightedText(text: string) {
+        try {
+            await createBlueskyPost(this, text);
+        } catch (error) {
+            if (error.message.includes('Failed to fetch')) {
+                new Notice('Failed to post. Could not connect to the internet.')
+            } else if (error.message.includes('Invalid identifier or password')) {
+                new Notice('Invalid bluesky handle or password. Please check your bluesky plugin settings.')
+            } else {
+                new Notice(`Failed to post: ${error.message}`);
+            }
+        }
     }
 
     async loadSettings() {
@@ -155,6 +168,16 @@ class BlueskySettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.postArchiveFolder)
                 .onChange(async (value) => {
                     this.plugin.settings.postArchiveFolder = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        new Setting(containerEl)
+            .setName('Confirm before posting')
+            .setDesc('Show a preview of the highlighted text and ask for confirmation before posting it. Turn off to post immediately.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.confirmBeforePosting)
+                .onChange(async (value) => {
+                    this.plugin.settings.confirmBeforePosting = value;
                     await this.plugin.saveSettings();
                 }));
     }

--- a/src/modals/ConfirmPostModal.ts
+++ b/src/modals/ConfirmPostModal.ts
@@ -1,0 +1,55 @@
+import { App, Modal, Setting } from "obsidian";
+
+export class ConfirmPostModal extends Modal {
+    private readonly text: string;
+    private readonly onConfirm: () => void;
+    private static readonly MAX_CHARS = 300;
+
+    constructor(app: App, text: string, onConfirm: () => void) {
+        super(app);
+        this.text = text;
+        this.onConfirm = onConfirm;
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+
+        contentEl.createEl("h2", { text: "Post to Bluesky?" });
+
+        contentEl.createDiv({
+            cls: 'bluesky-confirm-preview',
+            text: this.text
+        });
+
+        const counter = contentEl.createDiv({
+            cls: 'bluesky-char-counter',
+            text: `${this.text.length}/${ConfirmPostModal.MAX_CHARS}`
+        });
+        if (this.text.length > ConfirmPostModal.MAX_CHARS) {
+            counter.classList.add('exceeded');
+        }
+
+        new Setting(contentEl)
+            .addButton((btn) =>
+                btn
+                    .setButtonText("Post")
+                    .setCta()
+                    .onClick(() => {
+                        this.close();
+                        this.onConfirm();
+                    })
+            )
+            .addButton((btn) =>
+                btn
+                    .setButtonText("Cancel")
+                    .onClick(() => {
+                        this.close();
+                    })
+            );
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -282,3 +282,15 @@
     opacity: 1;
     color: var(--text-error);
 }
+
+.bluesky-confirm-preview {
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    max-height: 40vh;
+    overflow-y: auto;
+    padding: var(--size-4-3);
+    margin-bottom: var(--size-4-2);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m);
+    background-color: var(--background-secondary);
+}


### PR DESCRIPTION
## Summary
- New `ConfirmPostModal`: running "Post highlighted text" now shows a preview of the selected text (whitespace preserved, scrollable) with a `n/300` character counter — including the red exceeded state — and Post/Cancel buttons
- New "Confirm before posting" toggle in settings, **on by default** (opt-out)
- Only affects the highlighted-text command; the Bluesky tab compose flow is unchanged
- Error handling for the command extracted into `postHighlightedText()` shared by both the confirmed and immediate paths

## Test plan
- [x] `tsc -noEmit` and `eslint .` pass
- [x] Manually verified in Obsidian: prompt appears with preview, Cancel aborts, Post publishes, toggle off posts immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)