### PR TITLE
Fix issues flagged by the Obsidian automated reviewer

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -40,6 +42,14 @@ jobs:
         run: |
           npm ci
           npm run build
+
+      - name: Generate artifact attestations
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
 
       - name: Create Tag
         run: |

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import process from "process";
-import builtins from "builtin-modules";
+import { builtinModules } from "node:module";
 
 const banner =
 `/*
@@ -31,7 +31,7 @@ const context = await esbuild.context({
 		"@lezer/common",
 		"@lezer/highlight",
 		"@lezer/lr",
-		...builtins],
+		...builtinModules],
 	format: "cjs",
 	target: "es2018",
 	logLevel: "info",

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,6 @@
 	"minAppVersion": "1.5.7",
 	"description": "Post to Bluesky.",
 	"author": "eharris128",
-	"authorUrl": "https://github.com/eharris128/obsidian-bluesky",
+	"authorUrl": "https://evanharris.dev/",
 	"isDesktopOnly": false
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
 	"id": "bluesky",
 	"name": "Bluesky",
 	"version": "1.3.0",
-	"minAppVersion": "0.15.0",
+	"minAppVersion": "1.5.7",
 	"description": "Post to Bluesky.",
 	"author": "eharris128",
-	"authorUrl": "https://bsky.app/profile/evanharris.bsky.social",
+	"authorUrl": "https://github.com/eharris128/obsidian-bluesky",
 	"isDesktopOnly": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
 				"@wdio/cli": "9.27.2",
 				"@wdio/local-runner": "9.27.2",
 				"@wdio/mocha-framework": "9.27.2",
-				"builtin-modules": "5.2.0",
 				"esbuild": "0.28.0",
 				"eslint": "10.4.1",
 				"globals": "17.6.0",
@@ -3150,19 +3149,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/builtin-modules": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.2.0.tgz",
-			"integrity": "sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/camelcase": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 		"@wdio/cli": "9.27.2",
 		"@wdio/local-runner": "9.27.2",
 		"@wdio/mocha-framework": "9.27.2",
-		"builtin-modules": "5.2.0",
 		"esbuild": "0.28.0",
 		"eslint": "10.4.1",
 		"globals": "17.6.0",

--- a/src/bluesky.ts
+++ b/src/bluesky.ts
@@ -4,11 +4,10 @@ import type BlueskyPlugin from '@/main'
 import { logger } from '@/utils/logger'
 import { parseMarkdownLinks, type MarkdownLink } from '@/utils/markdown'
 
-// Utility function to decode HTML entities
+// Utility function to decode HTML entities without writing to the live DOM
 const decodeHtmlEntities = (text: string): string => {
-  const textarea = document.createElement('textarea');
-  textarea.innerHTML = text;
-  return textarea.value;
+  const parsed = new DOMParser().parseFromString(text, 'text/html');
+  return parsed.documentElement.textContent ?? '';
 };
 
 interface ThreadPost {
@@ -67,7 +66,7 @@ export class BlueskyBot {
       let response;
       try {
         response = await this.agent.getProfile({ actor: handle });
-      } catch (error) {
+      } catch {
         if (!this.agent.session?.did) {
           await this.login();
         }
@@ -151,7 +150,7 @@ export class BlueskyBot {
               image: image
             };
           }
-        } catch (e) {
+        } catch {
           logger.warn('Failed to parse Reddit JSON, falling back to HTML');
         }
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ export default class BlueskyPlugin extends Plugin {
 
                 if (this.settings.confirmBeforePosting) {
                     new ConfirmPostModal(this.app, selectedText, () => {
-                        this.postHighlightedText(selectedText);
+                        void this.postHighlightedText(selectedText);
                     }).open();
                 } else {
                     await this.postHighlightedText(selectedText);
@@ -68,7 +68,7 @@ export default class BlueskyPlugin extends Plugin {
         });
 
         this.addRibbonIcon("megaphone", BLUESKY_TITLE, () => {
-            this.activateBlueskyTab();
+            void this.activateBlueskyTab();
         });
 
         this.addSettingTab(new BlueskySettingTab(this.app, this));

--- a/src/modals/LinkModal.ts
+++ b/src/modals/LinkModal.ts
@@ -50,7 +50,7 @@ export class LinkModal extends Modal {
                     })
             );
 
-        setTimeout(() => {
+        window.setTimeout(() => {
             const inputEl = contentEl.querySelector("input");
             inputEl?.focus();
         }, 50);

--- a/src/views/BlueskyTab.ts
+++ b/src/views/BlueskyTab.ts
@@ -60,55 +60,58 @@ export class BlueskyTab extends ItemView {
         }
 
         // Detect and preview links for any post in the thread
-        this.detectAndPreviewLink(text, true, index);
+        void this.detectAndPreviewLink(text, true, index);
 
         this.updateButtonStates();
     }
 
     private autoStyleUrls(editor: HTMLElement) {
-        const text = editor.textContent || '';
-        const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g;
-        
-        // Find all URLs in the text
-        const urls = [...text.matchAll(urlRegex)];
-        
-        if (urls.length === 0) return;
-        
-        // Check if any URLs are not already styled
-        const existingLinks = editor.querySelectorAll('.bluesky-link');
-        const styledUrls = Array.from(existingLinks).map(link => link.getAttribute('data-url'));
-        
-        let needsUpdate = false;
-        
-        for (const match of urls) {
-            const url = match[0];
-            if (!styledUrls.includes(url)) {
-                needsUpdate = true;
-                break;
+        const urlRegex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
+
+        let styledAny = false;
+        let madeChange = true;
+
+        // Wrap the first not-yet-styled URL, then re-walk. Rebuilding the walk
+        // after every change keeps text offsets valid as the DOM is mutated and
+        // avoids writing raw HTML to the editor.
+        while (madeChange) {
+            madeChange = false;
+
+            const walker = activeDocument.createTreeWalker(editor, NodeFilter.SHOW_TEXT);
+            let node: Node | null;
+            while ((node = walker.nextNode())) {
+                // Skip text that already lives inside a styled link
+                if (node.parentElement?.closest('.bluesky-link')) continue;
+
+                const nodeText = node.textContent || '';
+                const match = nodeText.match(urlRegex);
+                if (!match || match.index === undefined) continue;
+
+                const url = match[0];
+                const range = activeDocument.createRange();
+                range.setStart(node, match.index);
+                range.setEnd(node, match.index + url.length);
+
+                const linkEl = createSpan({
+                    cls: 'bluesky-link',
+                    text: url,
+                    attr: { 'data-url': url, 'data-original-text': url, title: url }
+                });
+
+                range.deleteContents();
+                range.insertNode(linkEl);
+
+                styledAny = true;
+                madeChange = true;
+                break; // DOM changed; restart the walk
             }
         }
-        
-        if (!needsUpdate) return;
-        
-        // Simple approach: replace innerHTML with styled URLs
-        let html = editor.innerHTML;
-        
-        for (const match of urls) {
-            const url = match[0];
-            if (!styledUrls.includes(url)) {
-                const linkHtml = `<span class="bluesky-link" data-url="${url}" data-original-text="${url}" title="${url}">${url}</span>`;
-                // Only replace the first occurrence to avoid replacing already styled ones
-                html = html.replace(url, linkHtml);
-            }
-        }
-        
-        if (html !== editor.innerHTML) {
-            editor.innerHTML = html;
-            
+
+        if (styledAny) {
             // Place cursor at the end of the content
-            const selection = window.getSelection();
+            const selection = activeWindow.getSelection();
             if (selection) {
-                const range = document.createRange();
+                const range = activeDocument.createRange();
                 range.selectNodeContents(editor);
                 range.collapse(false);
                 selection.removeAllRanges();
@@ -129,20 +132,19 @@ export class BlueskyTab extends ItemView {
             const range = this.createRangeFromTextOffsets(editor, match.start, match.end);
             if (!range) return;
 
-            const linkElement = document.createElement('span');
-            linkElement.className = 'bluesky-link';
-            linkElement.textContent = match.text;
-            linkElement.setAttribute('data-url', match.url);
-            linkElement.setAttribute('title', match.url);
-            linkElement.setAttribute('data-original-text', match.text);
+            const linkElement = createSpan({
+                cls: 'bluesky-link',
+                text: match.text,
+                attr: { 'data-url': match.url, title: match.url, 'data-original-text': match.text }
+            });
 
             range.deleteContents();
             range.insertNode(linkElement);
 
             // Place the cursor right after the new link
-            const selection = window.getSelection();
+            const selection = activeWindow.getSelection();
             if (selection) {
-                const cursor = document.createRange();
+                const cursor = activeDocument.createRange();
                 cursor.setStartAfter(linkElement);
                 cursor.collapse(true);
                 selection.removeAllRanges();
@@ -155,7 +157,7 @@ export class BlueskyTab extends ItemView {
 
     // Build a DOM range covering the given character offsets of the editor's text
     private createRangeFromTextOffsets(root: HTMLElement, start: number, end: number): Range | null {
-        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+        const walker = activeDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT);
         let pos = 0;
         let startNode: Node | null = null;
         let startOffset = 0;
@@ -179,7 +181,7 @@ export class BlueskyTab extends ItemView {
 
         if (!startNode || !endNode) return null;
 
-        const range = document.createRange();
+        const range = activeDocument.createRange();
         range.setStart(startNode, startOffset);
         range.setEnd(endNode, endOffset);
         return range;
@@ -206,17 +208,17 @@ export class BlueskyTab extends ItemView {
                 linkElement.textContent = originalText;
                 
                 // Create a text node for the extra text and insert it after the link
-                const textNode = document.createTextNode(extraText);
+                const textNode = activeDocument.createTextNode(extraText);
                 if (linkElement.nextSibling) {
                     linkElement.parentNode?.insertBefore(textNode, linkElement.nextSibling);
                 } else {
                     linkElement.parentNode?.appendChild(textNode);
                 }
-                
+
                 // Move cursor to the end of the new text
-                const selection = window.getSelection();
+                const selection = activeWindow.getSelection();
                 if (selection) {
-                    const range = document.createRange();
+                    const range = activeDocument.createRange();
                     range.setStart(textNode, textNode.textContent?.length || 0);
                     range.collapse(true);
                     selection.removeAllRanges();
@@ -258,7 +260,26 @@ export class BlueskyTab extends ItemView {
     private handlePaste(event: ClipboardEvent) {
         event.preventDefault();
         const text = event.clipboardData?.getData('text/plain') || '';
-        document.execCommand('insertText', false, text);
+        if (!text) return;
+
+        const editor = event.currentTarget as HTMLElement;
+        const selection = activeWindow.getSelection();
+        if (!selection || selection.rangeCount === 0) return;
+
+        // Insert the plain text at the caret, replacing any current selection
+        const range = selection.getRangeAt(0);
+        range.deleteContents();
+        const textNode = activeDocument.createTextNode(text);
+        range.insertNode(textNode);
+
+        // Move the caret to just after the inserted text
+        range.setStartAfter(textNode);
+        range.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        // Default paste was prevented, so run the normal input handling manually
+        editor.dispatchEvent(new Event('input', { bubbles: true }));
     }
 
     private async detectAndPreviewLink(text: string, preserveManualLinks = false, postIndex = 0) {
@@ -432,7 +453,7 @@ export class BlueskyTab extends ItemView {
     }
 
     private handleLinkInsertion(editor: HTMLElement) {
-        const selection = window.getSelection();
+        const selection = activeWindow.getSelection();
         if (!selection || selection.rangeCount === 0) {
             new Notice('Please select text to turn into a link');
             return;
@@ -446,55 +467,50 @@ export class BlueskyTab extends ItemView {
             return;
         }
 
-        new LinkModal(this.app, async (url) => {
+        new LinkModal(this.app, (url) => {
             if (!url) return;
 
             // Create a link element
-            const linkElement = document.createElement('span');
-            linkElement.className = 'bluesky-link';
-            linkElement.textContent = selectedText;
-            linkElement.setAttribute('data-url', url);
-            linkElement.setAttribute('title', url);
-            linkElement.setAttribute('data-original-text', selectedText);
-            
+            const linkElement = createSpan({
+                cls: 'bluesky-link',
+                text: selectedText,
+                attr: { 'data-url': url, title: url, 'data-original-text': selectedText }
+            });
+
             // Replace the selected text with the link element
             range.deleteContents();
             range.insertNode(linkElement);
-            
+
             // Clear selection
             selection.removeAllRanges();
-            
+
             // Update the stored post content
             const index = parseInt(editor.getAttribute('data-index') || '0');
             this.posts[index] = this.getEditorText(editor);
-            
+
             // Store link information for posting
             if (!this.linkRanges) {
                 this.linkRanges = [];
             }
-            
+
             this.linkRanges.push({
                 start: 0, // We'll calculate this properly when posting
                 end: 0,
                 url: url,
                 text: selectedText
             });
-            
+
             this.updateButtonStates();
-            
+
             // Show a visual indicator that the link has been added
             new Notice(`Link added to "${selectedText}"`);
-            
-            // Try to show link preview for the manually added link
-            try {
-                const index = parseInt(editor.getAttribute('data-index') || '0');
-                // Only show preview if we don't already have one for this post
-                if (!this.linkMetadata.get(index)) {
-                    await this.detectAndPreviewLink(url, false, index);
-                }
-            } catch (error) {
-                logger.warn('Could not fetch link preview:', error);
-                // Link is still added, just without preview
+
+            // Try to show link preview for the manually added link. The link is
+            // already added, so a failed preview is non-fatal.
+            if (!this.linkMetadata.get(index)) {
+                void this.detectAndPreviewLink(url, false, index).catch((error) => {
+                    logger.warn('Could not fetch link preview:', error);
+                });
             }
         }).open();
     }
@@ -573,7 +589,7 @@ export class BlueskyTab extends ItemView {
 
         // Pair each post with the links from its editor before filtering,
         // so post text and link ranges stay aligned
-        const editors = Array.from(this.containerEl.querySelectorAll('.bluesky-editor')) as HTMLElement[];
+        const editors = Array.from(this.containerEl.querySelectorAll<HTMLElement>('.bluesky-editor'));
         const validPosts = this.posts
             .map((text, index) => ({
                 text,
@@ -688,7 +704,7 @@ export class BlueskyTab extends ItemView {
             cls: 'bluesky-post-btn mod-primary'
         });
 
-        postButton.addEventListener('click', () => this.publishContent());
+        postButton.addEventListener('click', () => { void this.publishContent(); });
 
         this.updateButtonStates();
     }

--- a/styles.css
+++ b/styles.css
@@ -56,7 +56,6 @@
 .bluesky-link {
     color: var(--interactive-accent);
     text-decoration: underline;
-    text-decoration-color: var(--interactive-accent);
     cursor: pointer;
     display: inline;
     white-space: nowrap;
@@ -146,7 +145,7 @@
     color: var(--text-muted);
 }
 
-.bluesky-close-post {
+.bluesky-compose .bluesky-close-post {
     position: absolute;
     right: 12px;
     top: 1px;
@@ -155,8 +154,8 @@
     padding: 4px;
     z-index: 1;
     transition: box-shadow 0.2s ease;
-    background: transparent !important;
-    box-shadow: none !important;
+    background: transparent;
+    box-shadow: none;
     &:hover {
         color: var(--text-error);
     }


### PR DESCRIPTION
Addresses the items the Obsidian automated plugin reviewer flagged, plus a small metadata fix.

## Changes
- **DOM safety**: stop writing raw HTML to the editor. `autoStyleUrls`, link insertion, and HTML-entity decoding now build nodes via the DOM/`DOMParser` and ranges instead of `innerHTML`.
- **Paste handling**: replace the deprecated `document.execCommand('insertText', ...)` with manual range-based insertion that re-dispatches an `input` event.
- **Multi-window correctness**: use `activeDocument`/`activeWindow` and `window.setTimeout` instead of the bare globals so the plugin behaves in pop-out/mobile contexts.
- **Floating promises**: mark fire-and-forget calls with `void` and tidy error handling around link previews.
- **Build/deps**: drop the `builtin-modules` dependency in favour of Node's `node:module` `builtinModules`.
- **Manifest**: bump `minAppVersion` to `1.5.7` and point `authorUrl` at https://evanharris.dev/.
- **CSS**: remove `!important` overrides and scope `.bluesky-close-post` under `.bluesky-compose`.
- **CI**: add build-provenance attestations to the release workflow.

No user-facing feature changes — this is compliance and correctness work ahead of submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)