### PR TITLE
feat: reply to an existing Bluesky post (#15)

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "spec": "test/unit/**/*.test.ts",
+  "node-option": ["import=tsx"],
+  "failZero": false
+}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ A new `megaphone` icon will appear in the left sidebar after you install the plu
     - Click "Post" to post to Bluesky.
 - If you prefer to use the command palette, you can run the `Open Bluesky tab` command.
 
+## Network use & privacy
+
+This plugin only contacts the network for the following, all initiated by you:
+
+- **Bluesky (`bsky.social`)** - to authenticate with your App Password and to
+  publish posts, threads, and uploaded images via the AT Protocol
+  (`@atproto/api`). Your credentials are stored locally and sent only to Bluesky.
+- **Link preview generation** - when your post includes a URL, the plugin fetches
+  that URL (and its preview image) to build the embedded link card. This means it
+  contacts whatever domain you linked to.
+
+No telemetry or analytics are collected. The plugin makes no network requests
+unless you post or include a link.
+
 ## Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -19,13 +19,25 @@ A new `megaphone` icon will appear in the left sidebar after you install the plu
     - Click "Post" to post to Bluesky.
 - If you prefer to use the command palette, you can run the `Open Bluesky tab` command.
 
+### Reply to a post
+
+You can add your post (or a whole thread) as a reply that continues an existing Bluesky post.
+
+- Open the Bluesky tab.
+- Paste the post's URL (e.g. `https://bsky.app/profile/handle/post/...`) into the **Reply to a Bluesky post** field at the top.
+- The plugin looks up the post and shows a preview so you can confirm the target.
+- Write your post or thread and click "Post" — it will be attached as a reply.
+
+Leave the field empty to post normally. Any public post can be replied to.
+
 ## Network use & privacy
 
 This plugin only contacts the network for the following, all initiated by you:
 
-- **Bluesky (`bsky.social`)** - to authenticate with your App Password and to
+- **Bluesky (`bsky.social`)** - to authenticate with your App Password, to
   publish posts, threads, and uploaded images via the AT Protocol
-  (`@atproto/api`). Your credentials are stored locally and sent only to Bluesky.
+  (`@atproto/api`), and to look up a post you choose to reply to. Your
+  credentials are stored locally and sent only to Bluesky.
 - **Link preview generation** - when your post includes a URL, the plugin fetches
   that URL (and its preview image) to build the embedded link card. This means it
   contacts whatever domain you linked to.

--- a/docs/plans/2026-06-22-001-feat-reply-to-existing-posts-plan.md
+++ b/docs/plans/2026-06-22-001-feat-reply-to-existing-posts-plan.md
@@ -1,0 +1,258 @@
+---
+title: "feat: Reply to existing Bluesky posts"
+type: feat
+date: 2026-06-22
+---
+
+# feat: Reply to existing Bluesky posts
+
+## Summary
+
+Add an optional "Reply to" field to the Bluesky compose tab: paste a `bsky.app`
+post URL, and the post (or whole thread) you compose publishes as a reply that
+continues that post's thread. Works for any public post. Closes issue #15.
+
+---
+
+## Problem Frame
+
+The plugin can compose a standalone post or a brand-new thread, but every thread
+it creates starts a fresh root — there is no way to attach to a post that already
+exists on Bluesky. Issue #15 ("Support adding posts to previous posts") asks for
+exactly that: continue an already-published post's thread from Obsidian.
+
+The reply primitives already exist internally. `createThread` in `src/bluesky.ts`
+already builds `reply: { root, parent }` strongrefs to chain its own posts; it
+just always seeds the root from the first post it creates. The missing pieces are
+(1) turning a user-supplied `bsky.app` URL into the AT-protocol refs of an
+existing post, (2) deriving the correct *thread root* for that post, and (3) a UI
+surface to enter and confirm the target.
+
+---
+
+## Requirements
+
+### Reply targeting and resolution
+
+- R1. The user can enter a `bsky.app` post URL in the compose tab to designate a post to reply to.
+- R2. The plugin resolves the URL — whether the profile segment is a handle or a DID — to the target post's AT-URI and CID, and derives the correct thread root.
+- R3. Resolution works for any public post; the target need not be authored by the logged-in account.
+
+### Composing and posting
+
+- R4. A composed single post publishes as a reply to the target. A composed multi-post thread attaches in order, each post chained off the previous, all sharing the target's thread root.
+- R5. The local archive copy (when enabled) records replies the same way it records other posts.
+
+### UX and validation
+
+- R6. Before publishing, the UI shows a preview of the target post (author plus a text snippet) so the user can confirm the target.
+- R7. An invalid or unresolvable URL surfaces a clear error and blocks publishing until the field is corrected or cleared; an empty field posts normally with no reply.
+- R8. Reply state clears after a successful post and on view reset.
+
+### Testing and docs
+
+- R9. The pure resolution logic (URL parse, root derivation, target resolution against an injected agent) is covered by unit tests; non-network field behavior is covered by e2e tests.
+- R10. The README documents replying to a post.
+
+---
+
+## Key Technical Decisions
+
+- **Thread-root derivation.** When replying, `parent` is the target post's
+  strongref and `root` is the target's *existing* thread root if the target is
+  itself a reply, otherwise the target itself: `root = target.record.reply?.root ?? {uri,cid}(target)`.
+  Bluesky threads reference the root, not just the immediate parent; using the
+  parent as the root breaks threading when replying to a nested post.
+- **obsidian-free, agent-injected resolution module.** All resolution logic lives
+  in a new `src/utils/reply.ts` that imports only `@atproto/api` types (erased at
+  runtime) and takes the agent as a parameter. `BlueskyBot` (which imports
+  `obsidian`) calls into it. This keeps the `obsidian` runtime out of the module
+  so it is unit-testable in plain Node with a mock agent.
+- **Unified thread-seeding.** Rather than branch `createThread`, seed its existing
+  `root`/`parent` loop variables from the optional reply refs. With no reply the
+  first composed post becomes the root (today's behavior); with a reply the loop
+  is seeded with the external root and target so the first post replies to the
+  target and the root stays external throughout. One code path.
+- **Unauthenticated resolve with login fallback.** Resolution tries
+  `resolveHandle`/`getPosts` unauthenticated and logs in on failure, mirroring the
+  existing `fetchBlueskyProfileMetadata` pattern. Public posts resolve without
+  credentials.
+- **New mocha + tsx unit lane.** A second test lane (`test:unit`) covers the
+  network-touching resolution logic the provider-free e2e suite is forbidden to
+  exercise. `mocha` and `tsx` are already dev dependencies.
+- **Block on unresolved URL.** A non-empty URL field that fails to resolve blocks
+  posting instead of silently posting a standalone post — replying to the wrong
+  thing (or nothing) is a worse failure than a blocked button.
+
+---
+
+## High-Level Technical Design
+
+Resolve-and-reply data flow, from pasted URL to seeded reply refs:
+
+```mermaid
+flowchart TB
+  A[User pastes bsky.app post URL] --> B[parseBskyPostUrl]
+  B -->|null| E[Show error; block posting until cleared or fixed]
+  B -->|actor + rkey| C{actor is a DID?}
+  C -->|no| D[agent.resolveHandle to DID]
+  C -->|yes| F[Build AT URI at://did/app.bsky.feed.post/rkey]
+  D --> F
+  F --> G[agent.getPosts]
+  G -->|empty / not found| E
+  G -->|PostView| H[deriveReplyRef]
+  H --> I{target.record.reply present?}
+  I -->|yes: target is itself a reply| J[root = target's existing root]
+  I -->|no: target is top-level| K[root = target]
+  J --> L[parent = target; render target preview]
+  K --> L
+  L --> M[On publish: pass root + parent refs]
+  M --> N[createPost / createThread seed reply refs]
+```
+
+Per-post chaining inside a thread reply: post 0 gets `{ root, parent: target }`;
+each later post gets `{ root, parent: previously-posted }`. The root is constant
+(the external thread's root) for every post.
+
+---
+
+## Implementation Units
+
+### U1. Add a mocha + tsx unit-test lane
+
+- **Goal:** Enable fast, network-free unit tests for `src/` logic without touching the e2e suite.
+- **Requirements:** R9
+- **Dependencies:** none
+- **Files:** `package.json` (add `test:unit` script), `.mocharc.json` (new), `test/unit/` (new dir), `test/README.md` (note the new lane)
+- **Approach:** Configure mocha to run `test/unit/**/*.test.ts` through the `tsx` loader (e.g. `mocha --import tsx`). Keep it fully separate from the wdio config and the `test:e2e` script. Unit tests import modules under test by relative path (`../../src/utils/reply`) rather than the `@/` alias, so the lane needs no tsconfig-path resolver. Modules under unit test must not import `obsidian` (enforced by design in U2/U3).
+- **Patterns to follow:** existing `test/README.md` layout table and the provider-free philosophy it documents.
+- **Test scenarios:** Test expectation: none — scaffolding. Verified by U2's tests running green under `npm run test:unit`.
+- **Verification:** `npm run test:unit` discovers and runs a `.test.ts` file under `test/unit/` and `npm run test:e2e` is unaffected.
+
+### U2. URL parsing and reply-ref derivation (pure)
+
+- **Goal:** Provide the two pure functions the feature is built on, fully unit-tested.
+- **Requirements:** R1, R2
+- **Dependencies:** U1
+- **Files:** `src/utils/reply.ts` (new), `test/unit/reply.test.ts` (new)
+- **Approach:** `parseBskyPostUrl(url)` returns `{ actor, rkey } | null` for `https://bsky.app/profile/{handleOrDid}/post/{rkey}`, tolerating trailing slashes and query strings; non-matching URLs return `null`. `deriveReplyRef(target)` takes a fetched `PostView` and returns `{ root, parent }` strongrefs per the root-derivation KTD. Export a `ReplyRefs` type. No `obsidian` import; `@atproto/api` used for types only.
+- **Patterns to follow:** the existing profile-URL regex `bsky\.app/profile/([^/?]+)` in `fetchBlueskyProfileMetadata` (`src/bluesky.ts`); `getPostUrl` (`src/bluesky.ts`) which constructs these URLs.
+- **Test scenarios:**
+  - `parseBskyPostUrl` happy path: standard URL → `{ actor: handle, rkey }`.
+  - `parseBskyPostUrl` with a DID actor segment (`did:plc:...`) → parsed unchanged.
+  - `parseBskyPostUrl` tolerates a trailing slash and a `?query` suffix.
+  - `parseBskyPostUrl` edge: profile URL with no `/post/` segment → `null`.
+  - `parseBskyPostUrl` edge: non-bsky URL and empty string → `null`.
+  - `deriveReplyRef` on a top-level target (no `record.reply`) → `root === parent === {uri,cid}` of target.
+  - `deriveReplyRef` on a reply target (`record.reply.root` set) → `root` is the target's existing root; `parent` is the target.
+- **Verification:** `npm run test:unit` passes; both functions exported and typed.
+
+### U3. Target resolution against an injected agent
+
+- **Goal:** Turn a pasted URL into reply refs plus a preview, using the agent but no `obsidian`.
+- **Requirements:** R2, R3, R6
+- **Dependencies:** U2
+- **Files:** `src/utils/reply.ts` (extend), `test/unit/reply.test.ts` (extend)
+- **Approach:** `resolveReplyTarget(agent, url)` returns `{ refs: ReplyRefs, preview: { authorHandle, authorName?, text } } | null`. Flow: `parseBskyPostUrl` → if `actor` is not a DID, `agent.resolveHandle({ handle })` → build AT URI → `agent.getPosts({ uris: [uri] })` → take the single `PostView` → `deriveReplyRef`. Return `null` on parse failure, empty `getPosts` result, or thrown error. The function is agent-agnostic (the caller passes `this.agent` or a fake).
+- **Patterns to follow:** `fetchBlueskyProfileMetadata` in `src/bluesky.ts` for the try-unauthenticated/handle-resolution shape.
+- **Test scenarios:**
+  - Happy path with a handle actor: mock agent resolves handle then returns a top-level `PostView`; result carries correct `refs` and a preview with author + snippet.
+  - Happy path with a DID actor: `resolveHandle` is *not* called; AT URI built directly from the DID.
+  - Reply target: `PostView.record.reply.root` set → returned `refs.root` is the external root (integration of U2's `deriveReplyRef`).
+  - `getPosts` returns an empty `posts` array → `null`.
+  - `agent.getPosts` throws → `null` (no exception escapes).
+  - Malformed URL → `null` and the agent is never called.
+- **Verification:** `npm run test:unit` passes with a hand-rolled mock agent exposing `resolveHandle` and `getPosts`.
+
+### U4. Thread reply refs through BlueskyBot
+
+- **Goal:** Let `BlueskyBot` accept a reply target and attach single posts and threads to it.
+- **Requirements:** R4, R5
+- **Dependencies:** U3
+- **Files:** `src/bluesky.ts`
+- **Approach:** Add a thin `BlueskyBot.resolveReplyTarget(url)` that calls the util with `this.agent` (logging in and retrying on failure). Add an optional `replyRefs?: ReplyRefs` parameter to `createPost` and `createThread`. In `createPost`, pass `reply: replyRefs` to `agent.post` when present. In `createThread`, seed the loop's `rootPost` and `lastPost` from `replyRefs` (root and parent respectively) so the first post replies to the target and the root stays external; the existing chaining handles the rest unchanged. `archivePosts` is unaffected (R5).
+- **Patterns to follow:** the existing `createThread` root/parent loop in `src/bluesky.ts`; `getProfile`-then-`login` fallback in `fetchBlueskyProfileMetadata`.
+- **Test scenarios:**
+  - Covered indirectly: the root/parent selection these methods pass through is unit-tested in U2/U3. The multi-post network chaining itself is not automatable under the provider-free suite — log this coverage boundary rather than implying it is tested.
+  - Manual verification scenario: reply with a single post to a top-level post and to a nested reply; reply with a 3-post thread; confirm on Bluesky that all share the original thread's root and chain in order.
+- **Verification:** `npm run build` type-checks; existing non-reply post/thread paths still compile and behave identically (the new parameter is optional).
+
+### U5. "Reply to" field, target preview, and publish wiring
+
+- **Goal:** Surface the feature in the compose tab and connect it to posting.
+- **Requirements:** R1, R6, R7, R8
+- **Dependencies:** U4
+- **Files:** `src/views/BlueskyTab.ts`, `styles.css`, `test/specs/tab.e2e.ts`
+- **Approach:** Add an optional URL input at the top of `display()`. On change/blur with a parseable URL, call `bot.resolveReplyTarget`, showing loading → preview (author + snippet) or an inline error. Store the resolved `ReplyRefs` and a "field non-empty but unresolved" flag in view state. In `publishContent`, pass the stored refs to `createPost`/`createThread`. Extend `updateButtonStates` so a non-empty-but-unresolved field disables Post (R7); an empty field leaves posting unchanged. Clear reply state on successful post and in `display()` reset (R8).
+- **Patterns to follow:** `showLinkPreview` / `detectAndPreviewLink` for the fetch-then-render-preview pattern and loading/remove affordances; `updateButtonStates` for validation gating; the `display()` reset block that already clears link state.
+- **Test scenarios:**
+  - Happy path: the "Reply to" field renders in the compose tab.
+  - Edge: pasting a malformed URL shows an inline error and renders no preview.
+  - Error path: with a non-empty unresolved field, the Post button is disabled; clearing the field re-enables posting.
+  - Integration: composing with an empty reply field posts normally (no regression to existing single/thread posting).
+  - State: after a reset/redisplay, the reply field and any preview are cleared.
+  - Note: e2e cannot drive the network resolve (provider-free suite), so the resolved-preview happy path and actual reply posting are out of e2e scope — covered by U3 unit tests and U4 manual verification.
+- **Verification:** `npm run test:e2e` passes including the new tab assertions; manual reply post succeeds end to end.
+
+### U6. Document replying in the README
+
+- **Goal:** Tell users how to reply to a post.
+- **Requirements:** R10
+- **Dependencies:** U5
+- **Files:** `README.md`
+- **Approach:** Add a short "Reply to a post" subsection under the usage guide (paste a `bsky.app` post URL, confirm the preview, post or build a thread). Remove issue #15's intent from the roadmap if listed. The existing "Network use & privacy" section already covers Bluesky API calls and needs no change — resolution uses the same `bsky.social` service already disclosed.
+- **Patterns to follow:** existing "How to Post" and "Network use & privacy" sections in `README.md`.
+- **Test scenarios:** Test expectation: none — docs only.
+- **Verification:** README renders; reply flow description matches the shipped UI.
+
+---
+
+## Scope Boundaries
+
+### In scope
+
+Paste-URL reply entry in the compose tab; single-post and full-thread replies;
+target preview confirmation; replies to any public post; the unit + e2e coverage
+above; README docs.
+
+### Deferred to follow-up work
+
+- An archive picker to choose a previously saved post to continue (the user chose URL entry only for this pass).
+- A "reply to my latest post" one-click shortcut.
+- Reply support from the "Post highlighted text" command (`postHighlightedText` in `src/main.ts`) — reply stays a compose-tab feature.
+
+### Outside this feature
+
+- Quote-posts, editing or deleting replies, and media attached to replies (existing media limitations are unchanged).
+- Resolving anything other than standard `bsky.app/profile/{handleOrDid}/post/{rkey}` URLs (e.g. raw `at://` URIs or third-party AppView hosts).
+
+---
+
+## Risks & Dependencies
+
+- **AT Protocol reply shape is a hard external contract.** Wrong root derivation
+  produces visibly broken threads on Bluesky. Mitigated by unit-testing
+  `deriveReplyRef` against both top-level and nested targets, and by manual
+  end-to-end verification in U4.
+- **`@atproto/api` version pin.** Resolution relies on `resolveHandle`,
+  `getPosts`, and the `ReplyRef`/`StrongRef` shapes confirmed in `0.20.9`. A
+  future SDK bump should re-verify these.
+- **Network behavior untestable in e2e.** The provider-free suite cannot exercise
+  resolution or reply posting; the unit lane (U1–U3) is the safety net, with the
+  gap stated explicitly rather than papered over.
+
+---
+
+## Sources / Research
+
+- `src/bluesky.ts` — `createThread` root/parent chaining loop (the seed point for
+  U4); `fetchBlueskyProfileMetadata` (handle resolution + login-fallback pattern);
+  `getPostUrl` and the `bsky\.app/profile/([^/?]+)` regex (URL handling to mirror).
+- `src/views/BlueskyTab.ts` — `showLinkPreview` / `detectAndPreviewLink` (preview
+  pattern), `updateButtonStates` (validation gating), `display()` reset block.
+- `@atproto/api@0.20.9`, verified against the installed package: `agent.resolveHandle({handle}) → {did}`;
+  `agent.getPosts({uris}) → {posts: PostView[]}`; `ReplyRef = {root, parent}`;
+  `ComAtprotoRepoStrongRef.Main = {uri, cid}`; `agent.post({reply})`.
+- `test/README.md` — provider-free, e2e-only test philosophy that motivates the
+  separate unit lane.
+- Issue #15 (`Support adding posts to previous posts`).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"lint": "eslint .",
-		"test:unit": "mocha",
+		"test:unit": "tsc -noEmit -p test/unit && mocha",
 		"test:e2e": "npm run build && tsc -noEmit -p test && node scripts/stage-plugin.mjs && wdio run ./wdio.conf.mts",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"lint": "eslint .",
+		"test:unit": "mocha",
 		"test:e2e": "npm run build && tsc -noEmit -p test && node scripts/stage-plugin.mjs && wdio run ./wdio.conf.mts",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},

--- a/src/bluesky.ts
+++ b/src/bluesky.ts
@@ -3,6 +3,7 @@ import { AtpAgent, RichText, AppBskyEmbedExternal, BlobRef, type $Typed } from '
 import type BlueskyPlugin from '@/main'
 import { logger } from '@/utils/logger'
 import { parseMarkdownLinks, type MarkdownLink } from '@/utils/markdown'
+import { resolveReplyTarget as resolveReplyTargetUtil, type ReplyRefs, type ReplyTarget } from '@/utils/reply'
 
 // Utility function to decode HTML entities without writing to the live DOM
 const decodeHtmlEntities = (text: string): string => {
@@ -48,6 +49,22 @@ export class BlueskyBot {
       logger.error('Failed to login:', error)
       throw error
     }
+  }
+
+  // Resolve a bsky.app post URL into a reply target. Public posts resolve
+  // without auth; if that yields nothing and we have no session, log in and
+  // retry once (mirrors fetchBlueskyProfileMetadata).
+  async resolveReplyTarget(url: string): Promise<ReplyTarget | null> {
+    let target = await resolveReplyTargetUtil(this.agent, url)
+    if (!target && !this.agent.session?.did) {
+      try {
+        await this.login()
+      } catch {
+        return null
+      }
+      target = await resolveReplyTargetUtil(this.agent, url)
+    }
+    return target
   }
 
   async fetchBlueskyProfileMetadata(url: string): Promise<LinkMetadata | null> {
@@ -300,7 +317,7 @@ export class BlueskyBot {
     return richText
   }
 
-  async createPost(text: string, linkMetadata?: LinkMetadata, linkRanges?: Array<{start: number, end: number, url: string, text: string}>): Promise<boolean> {
+  async createPost(text: string, linkMetadata?: LinkMetadata, linkRanges?: Array<{start: number, end: number, url: string, text: string}>, replyRefs?: ReplyRefs): Promise<boolean> {
     try {
       if (!this.agent.session?.did) {
         throw new Error('Not logged in')
@@ -334,7 +351,8 @@ export class BlueskyBot {
       const result = await this.agent.post({
         text: richText.text,
         facets: richText.facets,
-        embed
+        embed,
+        ...(replyRefs ? { reply: replyRefs } : {})
       })
       new Notice('Successfully posted to Bluesky!');
       await this.archivePosts([{ text: richText.text, url: this.getPostUrl(result.uri) }])
@@ -350,11 +368,14 @@ export class BlueskyBot {
     }
   }
 
-  async createThread(posts: string[], linkRanges?: Array<Array<{start: number, end: number, url: string, text: string}>>): Promise<boolean> {
+  async createThread(posts: string[], linkRanges?: Array<Array<{start: number, end: number, url: string, text: string}>>, replyRefs?: ReplyRefs): Promise<boolean> {
     if (!posts.length) return false
 
-    let lastPost: { uri: string; cid: string } | null = null
-    let rootPost: { uri: string; cid: string } | null = null
+    // When replying to an existing post, seed the chain with that post's thread
+    // root and the target as the first parent. The root then stays constant for
+    // the whole thread; without a reply target the first post becomes the root.
+    let lastPost: { uri: string; cid: string } | null = replyRefs?.parent ?? null
+    let rootPost: { uri: string; cid: string } | null = replyRefs?.root ?? null
     const published: Array<{ text: string; url: string }> = []
 
     for (let i = 0; i < posts.length; i++) {

--- a/src/utils/reply.ts
+++ b/src/utils/reply.ts
@@ -1,0 +1,37 @@
+import type { AppBskyFeedDefs } from '@atproto/api'
+
+// A Bluesky strong reference: a record's AT-URI plus its CID.
+export interface StrongRef {
+  uri: string
+  cid: string
+}
+
+// The root + parent refs needed to attach a reply into a thread.
+export interface ReplyRefs {
+  root: StrongRef
+  parent: StrongRef
+}
+
+// Match a bsky.app post URL: https://bsky.app/profile/<handle-or-did>/post/<rkey>
+const BSKY_POST_URL = /bsky\.app\/profile\/([^/?#]+)\/post\/([^/?#]+)/
+
+// Parse a bsky.app post URL into its actor (handle or DID) and record key.
+// Returns null for anything that isn't a post URL.
+export function parseBskyPostUrl(url: string): { actor: string; rkey: string } | null {
+  if (typeof url !== 'string') return null
+  const match = url.match(BSKY_POST_URL)
+  if (!match) return null
+  const [, actor, rkey] = match
+  if (!actor || !rkey) return null
+  return { actor, rkey }
+}
+
+// Build the reply refs for replying to a post. The parent is the target itself;
+// the root is the target's existing thread root when the target is itself a
+// reply, otherwise the target (a top-level post is its own root).
+export function deriveReplyRef(post: AppBskyFeedDefs.PostView): ReplyRefs {
+  const parent: StrongRef = { uri: post.uri, cid: post.cid }
+  const record = post.record as { reply?: { root?: StrongRef } }
+  const root = record?.reply?.root ?? parent
+  return { root, parent }
+}

--- a/src/utils/reply.ts
+++ b/src/utils/reply.ts
@@ -35,3 +35,58 @@ export function deriveReplyRef(post: AppBskyFeedDefs.PostView): ReplyRefs {
   const root = record?.reply?.root ?? parent
   return { root, parent }
 }
+
+// The slice of an AtpAgent that target resolution needs. Kept minimal and
+// obsidian-free so this module stays unit-testable with a mock agent; a real
+// AtpAgent satisfies it structurally.
+export interface ReplyResolverAgent {
+  resolveHandle(params: { handle: string }): Promise<{ data: { did: string } }>
+  getPosts(params: { uris: string[] }): Promise<{ data: { posts: AppBskyFeedDefs.PostView[] } }>
+}
+
+// A resolved reply target: the refs needed to post the reply, plus a small
+// preview of the post being replied to for user confirmation.
+export interface ReplyTarget {
+  refs: ReplyRefs
+  preview: {
+    authorHandle: string
+    authorName?: string
+    text: string
+  }
+}
+
+// Resolve a bsky.app post URL into reply refs and a preview. Resolves the handle
+// to a DID when needed, fetches the post, and derives the thread refs. Returns
+// null for a non-post URL, a post that can't be fetched, or any request error.
+export async function resolveReplyTarget(
+  agent: ReplyResolverAgent,
+  url: string,
+): Promise<ReplyTarget | null> {
+  const parsed = parseBskyPostUrl(url)
+  if (!parsed) return null
+
+  try {
+    let did = parsed.actor
+    if (!did.startsWith('did:')) {
+      const resolved = await agent.resolveHandle({ handle: parsed.actor })
+      did = resolved.data.did
+    }
+
+    const atUri = `at://${did}/app.bsky.feed.post/${parsed.rkey}`
+    const response = await agent.getPosts({ uris: [atUri] })
+    const post = response.data.posts[0]
+    if (!post) return null
+
+    const record = post.record as { text?: string }
+    return {
+      refs: deriveReplyRef(post),
+      preview: {
+        authorHandle: post.author.handle,
+        authorName: post.author.displayName,
+        text: typeof record?.text === 'string' ? record.text : '',
+      },
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/views/BlueskyTab.ts
+++ b/src/views/BlueskyTab.ts
@@ -18,6 +18,7 @@ export class BlueskyTab extends ItemView {
     private linkRanges: Array<{start: number, end: number, url: string, text: string}> = [];
     private replyTarget: ReplyTarget | null = null; // resolved post to reply to
     private replyUrlPending = false; // reply field non-empty but unresolved/invalid
+    private replyRequestSeq = 0; // guards against out-of-order reply lookups
 
     constructor(leaf: WorkspaceLeaf, plugin: BlueskyPlugin) {
         super(leaf);
@@ -529,6 +530,10 @@ export class BlueskyTab extends ItemView {
         const replyContainer = this.containerEl.querySelector('.bluesky-reply') as HTMLElement | null;
         if (!replyContainer) return;
 
+        // Bump the sequence so any in-flight lookup from an earlier change
+        // becomes stale and discards its result instead of overwriting this one.
+        const seq = ++this.replyRequestSeq;
+
         this.clearReplyStatus(replyContainer);
 
         if (!url) {
@@ -552,27 +557,29 @@ export class BlueskyTab extends ItemView {
         this.updateButtonStates();
         const loadingEl = replyContainer.createDiv({ cls: 'bluesky-reply-loading', text: 'Looking up post…' });
 
+        let target: ReplyTarget | null = null;
         try {
-            const target = await this.bot.resolveReplyTarget(url);
-            loadingEl.remove();
-            if (!target) {
-                this.replyUrlPending = true;
-                this.showReplyError(replyContainer, "Couldn't find that post.");
-                this.updateButtonStates();
-                return;
-            }
-            this.replyTarget = target;
-            this.replyUrlPending = false;
-            this.showReplyPreview(replyContainer, target);
-            this.updateButtonStates();
+            target = await this.bot.resolveReplyTarget(url);
         } catch (error) {
-            loadingEl.remove();
             logger.warn('Failed to resolve reply target:', error);
+        }
+
+        // A newer change superseded this lookup — discard its result. The newer
+        // call's clearReplyStatus already removed this call's loading row.
+        if (seq !== this.replyRequestSeq) return;
+
+        loadingEl.remove();
+        if (!target) {
             this.replyTarget = null;
             this.replyUrlPending = true;
             this.showReplyError(replyContainer, "Couldn't find that post.");
             this.updateButtonStates();
+            return;
         }
+        this.replyTarget = target;
+        this.replyUrlPending = false;
+        this.showReplyPreview(replyContainer, target);
+        this.updateButtonStates();
     }
 
     private showReplyError(container: HTMLElement, message: string) {

--- a/src/views/BlueskyTab.ts
+++ b/src/views/BlueskyTab.ts
@@ -518,14 +518,18 @@ export class BlueskyTab extends ItemView {
         }).open();
     }
 
+    private clearReplyStatus(container: HTMLElement) {
+        container.querySelector('.bluesky-reply-preview')?.remove();
+        container.querySelector('.bluesky-reply-error')?.remove();
+        container.querySelector('.bluesky-reply-loading')?.remove();
+    }
+
     private async handleReplyUrlChange(rawUrl: string) {
         const url = rawUrl.trim();
         const replyContainer = this.containerEl.querySelector('.bluesky-reply') as HTMLElement | null;
         if (!replyContainer) return;
 
-        replyContainer.querySelector('.bluesky-reply-preview')?.remove();
-        replyContainer.querySelector('.bluesky-reply-error')?.remove();
-        replyContainer.querySelector('.bluesky-reply-loading')?.remove();
+        this.clearReplyStatus(replyContainer);
 
         if (!url) {
             this.replyTarget = null;
@@ -572,14 +576,12 @@ export class BlueskyTab extends ItemView {
     }
 
     private showReplyError(container: HTMLElement, message: string) {
-        container.querySelector('.bluesky-reply-preview')?.remove();
-        container.querySelector('.bluesky-reply-error')?.remove();
+        this.clearReplyStatus(container);
         container.createDiv({ cls: 'bluesky-reply-error', text: message });
     }
 
     private showReplyPreview(container: HTMLElement, target: ReplyTarget) {
-        container.querySelector('.bluesky-reply-preview')?.remove();
-        container.querySelector('.bluesky-reply-error')?.remove();
+        this.clearReplyStatus(container);
 
         const preview = container.createDiv({ cls: 'bluesky-reply-preview' });
         preview.createDiv({ cls: 'bluesky-reply-preview-label', text: 'Replying to' });

--- a/src/views/BlueskyTab.ts
+++ b/src/views/BlueskyTab.ts
@@ -527,7 +527,7 @@ export class BlueskyTab extends ItemView {
 
     private async handleReplyUrlChange(rawUrl: string) {
         const url = rawUrl.trim();
-        const replyContainer = this.containerEl.querySelector('.bluesky-reply') as HTMLElement | null;
+        const replyContainer = this.containerEl.querySelector<HTMLElement>('.bluesky-reply');
         if (!replyContainer) return;
 
         // Bump the sequence so any in-flight lookup from an earlier change
@@ -614,7 +614,7 @@ export class BlueskyTab extends ItemView {
             this.replyTarget = null;
             this.replyUrlPending = false;
             preview.remove();
-            const input = this.containerEl.querySelector('.bluesky-reply-input') as HTMLInputElement | null;
+            const input = this.containerEl.querySelector<HTMLInputElement>('.bluesky-reply-input');
             if (input) input.value = '';
             this.updateButtonStates();
         });

--- a/src/views/BlueskyTab.ts
+++ b/src/views/BlueskyTab.ts
@@ -1,5 +1,6 @@
 import { ItemView, Notice, WorkspaceLeaf } from "obsidian";
 import { BlueskyBot, type LinkMetadata } from '@/bluesky';
+import { parseBskyPostUrl, type ReplyTarget } from '@/utils/reply';
 import type BlueskyPlugin from '@/main';
 import { BLUESKY_TITLE, VIEW_TYPE_TAB } from '@/consts';
 import { LinkModal } from '@/modals/LinkModal';
@@ -15,6 +16,8 @@ export class BlueskyTab extends ItemView {
     private linkMetadata: Map<number, LinkMetadata> = new Map(); // Track metadata per post index
     private linkPreviewEls: Map<number, HTMLElement> = new Map(); // Track preview elements per post
     private linkRanges: Array<{start: number, end: number, url: string, text: string}> = [];
+    private replyTarget: ReplyTarget | null = null; // resolved post to reply to
+    private replyUrlPending = false; // reply field non-empty but unresolved/invalid
 
     constructor(leaf: WorkspaceLeaf, plugin: BlueskyPlugin) {
         super(leaf);
@@ -515,6 +518,99 @@ export class BlueskyTab extends ItemView {
         }).open();
     }
 
+    private async handleReplyUrlChange(rawUrl: string) {
+        const url = rawUrl.trim();
+        const replyContainer = this.containerEl.querySelector('.bluesky-reply') as HTMLElement | null;
+        if (!replyContainer) return;
+
+        replyContainer.querySelector('.bluesky-reply-preview')?.remove();
+        replyContainer.querySelector('.bluesky-reply-error')?.remove();
+        replyContainer.querySelector('.bluesky-reply-loading')?.remove();
+
+        if (!url) {
+            this.replyTarget = null;
+            this.replyUrlPending = false;
+            this.updateButtonStates();
+            return;
+        }
+
+        // Cheap offline check first — only hit the network for a real post URL
+        if (!parseBskyPostUrl(url)) {
+            this.replyTarget = null;
+            this.replyUrlPending = true;
+            this.showReplyError(replyContainer, 'Not a Bluesky post URL.');
+            this.updateButtonStates();
+            return;
+        }
+
+        this.replyTarget = null;
+        this.replyUrlPending = true;
+        this.updateButtonStates();
+        const loadingEl = replyContainer.createDiv({ cls: 'bluesky-reply-loading', text: 'Looking up post…' });
+
+        try {
+            const target = await this.bot.resolveReplyTarget(url);
+            loadingEl.remove();
+            if (!target) {
+                this.replyUrlPending = true;
+                this.showReplyError(replyContainer, "Couldn't find that post.");
+                this.updateButtonStates();
+                return;
+            }
+            this.replyTarget = target;
+            this.replyUrlPending = false;
+            this.showReplyPreview(replyContainer, target);
+            this.updateButtonStates();
+        } catch (error) {
+            loadingEl.remove();
+            logger.warn('Failed to resolve reply target:', error);
+            this.replyTarget = null;
+            this.replyUrlPending = true;
+            this.showReplyError(replyContainer, "Couldn't find that post.");
+            this.updateButtonStates();
+        }
+    }
+
+    private showReplyError(container: HTMLElement, message: string) {
+        container.querySelector('.bluesky-reply-preview')?.remove();
+        container.querySelector('.bluesky-reply-error')?.remove();
+        container.createDiv({ cls: 'bluesky-reply-error', text: message });
+    }
+
+    private showReplyPreview(container: HTMLElement, target: ReplyTarget) {
+        container.querySelector('.bluesky-reply-preview')?.remove();
+        container.querySelector('.bluesky-reply-error')?.remove();
+
+        const preview = container.createDiv({ cls: 'bluesky-reply-preview' });
+        preview.createDiv({ cls: 'bluesky-reply-preview-label', text: 'Replying to' });
+
+        const author = target.preview.authorName
+            ? `${target.preview.authorName} (@${target.preview.authorHandle})`
+            : `@${target.preview.authorHandle}`;
+        preview.createDiv({ cls: 'bluesky-reply-preview-author', text: author });
+
+        const snippet = target.preview.text.length > 200
+            ? target.preview.text.slice(0, 200) + '…'
+            : target.preview.text;
+        if (snippet) {
+            preview.createDiv({ cls: 'bluesky-reply-preview-text', text: snippet });
+        }
+
+        const removeBtn = preview.createEl('button', {
+            cls: 'bluesky-reply-preview-remove',
+            attr: { 'aria-label': 'Remove reply target' }
+        });
+        this.plugin.addIcon(removeBtn, 'lucide-x');
+        removeBtn.addEventListener('click', () => {
+            this.replyTarget = null;
+            this.replyUrlPending = false;
+            preview.remove();
+            const input = this.containerEl.querySelector('.bluesky-reply-input') as HTMLInputElement | null;
+            if (input) input.value = '';
+            this.updateButtonStates();
+        });
+    }
+
     private updateButtonStates() {
         const addThreadBtn = this.containerEl.querySelector('.add-bluesky-thread-btn') as HTMLButtonElement;
         if (addThreadBtn) {
@@ -526,7 +622,7 @@ export class BlueskyTab extends ItemView {
             const hasValidFirstPost = this.posts[0]?.trim().length > 0;
             const hasAnyContent = this.posts.some(post => post.trim());
             const isExceeded = this.posts.some(post => post.length > this.MAX_CHARS);
-            postButton.disabled = !hasValidFirstPost || !hasAnyContent || isExceeded;
+            postButton.disabled = !hasValidFirstPost || !hasAnyContent || isExceeded || this.replyUrlPending;
         }
     }
 
@@ -586,6 +682,7 @@ export class BlueskyTab extends ItemView {
 
     private async publishContent() {
         if (this.isPosting) return;
+        if (this.replyUrlPending) return; // reply URL entered but not resolved
 
         // Pair each post with the links from its editor before filtering,
         // so post text and link ranges stay aligned
@@ -601,19 +698,23 @@ export class BlueskyTab extends ItemView {
         try {
             this.isPosting = true;
             await this.bot.login();
+            const replyRefs = this.replyTarget?.refs;
             if (validPosts.length === 1) {
                 const metadata = this.linkMetadata.get(0); // Get metadata for first post
-                success = await this.bot.createPost(validPosts[0].text, metadata, validPosts[0].links);
+                success = await this.bot.createPost(validPosts[0].text, metadata, validPosts[0].links, replyRefs);
             } else {
                 success = await this.bot.createThread(
                     validPosts.map(post => post.text),
-                    validPosts.map(post => post.links)
+                    validPosts.map(post => post.links),
+                    replyRefs
                 );
             }
             this.posts = [''];
             this.linkMetadata.clear();
             this.linkPreviewEls.clear();
             this.linkRanges = [];
+            this.replyTarget = null;
+            this.replyUrlPending = false;
         } catch (error) {
             logger.error('Failed to post:', error);
             if (error.message.includes('Failed to fetch')) {
@@ -642,8 +743,23 @@ export class BlueskyTab extends ItemView {
         this.linkRanges = [];
         this.linkMetadata.clear();
         this.linkPreviewEls.clear();
+        this.replyTarget = null;
+        this.replyUrlPending = false;
 
         container.createEl("h4", { text: "Bluesky" });
+
+        // Optional reply target: paste a bsky.app post URL to attach this post
+        // (or thread) as a reply that continues that post's thread.
+        const replyContainer = container.createDiv({ cls: 'bluesky-reply' });
+        const replyInput = replyContainer.createEl('input', {
+            cls: 'bluesky-reply-input',
+            attr: {
+                type: 'text',
+                placeholder: 'Reply to a Bluesky post (paste its URL, optional)',
+                'aria-label': 'Reply to a Bluesky post by pasting its URL'
+            }
+        });
+        replyInput.addEventListener('change', () => { void this.handleReplyUrlChange(replyInput.value); });
 
         this.posts.forEach((post, index) => {
             const postContainer = container.createDiv({ cls: 'bluesky-compose' });

--- a/styles.css
+++ b/styles.css
@@ -299,3 +299,95 @@
     white-space: normal;
     overflow-wrap: anywhere;
 }
+
+.bluesky-reply {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.bluesky-reply-input {
+    width: 100%;
+    max-width: 513.667px;
+    padding: 8px;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 4px;
+    background: var(--background-primary);
+    font-size: 14px;
+}
+
+.bluesky-reply-input:focus {
+    border-color: var(--interactive-accent);
+    box-shadow: 0 0 0 2px var(--interactive-accent-hover);
+    outline: none;
+}
+
+.bluesky-reply-loading {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.bluesky-reply-error {
+    font-size: 12px;
+    color: var(--text-error);
+}
+
+.bluesky-reply-preview {
+    position: relative;
+    border: 1px solid var(--background-modifier-border);
+    border-left: 3px solid var(--interactive-accent);
+    border-radius: 8px;
+    padding: 12px;
+    padding-right: 36px;
+    background: var(--background-secondary);
+    max-width: 500px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.bluesky-reply-preview-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-faint);
+}
+
+.bluesky-reply-preview-author {
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.bluesky-reply-preview-text {
+    font-size: 13px;
+    color: var(--text-muted);
+    line-height: 1.4;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+}
+
+.bluesky-reply-preview-remove {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 24px;
+    height: 24px;
+    padding: 4px;
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 4px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.8;
+    transition: opacity 0.2s ease;
+}
+
+.bluesky-reply-preview-remove:hover {
+    opacity: 1;
+    background: var(--background-primary-alt);
+}

--- a/test/README.md
+++ b/test/README.md
@@ -21,6 +21,20 @@ OBSIDIAN_APP_VERSION=1.7.7 OBSIDIAN_INSTALLER_VERSION=1.7.7 npm run test:e2e
 Do **not** use `OBSIDIAN_APP_VERSION=earliest` — this plugin's `minAppVersion`
 is 0.15.0, far older than anything wdio-obsidian-service can download and run.
 
+## Unit tests
+
+Fast, network-free tests for pure `src/` logic, run with mocha via `tsx` (no
+Obsidian download, no build step):
+
+```bash
+npm run test:unit
+```
+
+Specs live in `test/unit/**/*.test.ts` and import the modules under test by
+relative path (e.g. `../../src/utils/reply`). Modules covered here must not
+import `obsidian` — keep that logic in obsidian-free helpers so it stays
+unit-testable in plain Node. Config is in `.mocharc.json` at the repo root.
+
 ## Layout
 
 | Path | Purpose |
@@ -30,6 +44,8 @@ is 0.15.0, far older than anything wdio-obsidian-service can download and run.
 | `test/plugin-dist/` | Staged plugin installed into test vaults (gitignored) |
 | `test/vaults/simple/` | Default test vault, copied fresh per run |
 | `test/specs/*.e2e.ts` | Mocha specs (own `test/tsconfig.json`, type-checked by `test:e2e`) |
+| `test/unit/*.test.ts` | Network-free unit specs run by `test:unit` (mocha + tsx) |
+| `.mocharc.json` (repo root) | Mocha config for the unit lane |
 | `test/logs/` | wdio logs (gitignored) |
 
 ## Conventions

--- a/test/specs/tab.e2e.ts
+++ b/test/specs/tab.e2e.ts
@@ -17,6 +17,19 @@ async function typeIntoEditor(text: string): Promise<void> {
 	}, LEAF_SELECTOR, text);
 }
 
+/**
+ * Set the reply-to field and fire its change event. Only use values that fail
+ * parseBskyPostUrl (or empty): a valid bsky.app post URL triggers a real
+ * resolveReplyTarget network call, which this offline suite must avoid.
+ */
+async function setReplyUrl(value: string): Promise<void> {
+	await browser.executeObsidian((_args, leafSelector, v) => {
+		const input = document.querySelector(`${leafSelector} .bluesky-reply-input`) as HTMLInputElement;
+		input.value = v;
+		input.dispatchEvent(new Event("change", { bubbles: true }));
+	}, LEAF_SELECTOR, value);
+}
+
 describe("Bluesky tab view", function () {
 	beforeEach(async function () {
 		await browser.executeObsidian(({ app }, viewType) => {
@@ -75,6 +88,36 @@ describe("Bluesky tab view", function () {
 
 		await leaf.$(".bluesky-close-post").click();
 		await expect(leaf.$$(".bluesky-compose")).toBeElementsArrayOfSize(1);
+	});
+
+	it("renders the reply-to field", async function () {
+		const leaf = browser.$(LEAF_SELECTOR);
+		const input = leaf.$(".bluesky-reply-input");
+		await expect(input).toExist();
+		expect(await input.getAttribute("placeholder")).toContain("Reply to a Bluesky post");
+	});
+
+	it("blocks Post and shows an error for an invalid reply URL", async function () {
+		const leaf = browser.$(LEAF_SELECTOR);
+		await typeIntoEditor("Hello world");
+		await expect(leaf.$(".bluesky-post-btn")).toBeEnabled();
+
+		await setReplyUrl("not a url");
+		await expect(leaf.$(".bluesky-reply-error")).toExist();
+		await expect(leaf.$(".bluesky-post-btn")).not.toBeEnabled();
+	});
+
+	it("re-enables Post when the invalid reply URL is cleared", async function () {
+		const leaf = browser.$(LEAF_SELECTOR);
+		await typeIntoEditor("Hello world");
+
+		await setReplyUrl("not a url");
+		await expect(leaf.$(".bluesky-reply-error")).toExist();
+		await expect(leaf.$(".bluesky-post-btn")).not.toBeEnabled();
+
+		await setReplyUrl("");
+		await expect(leaf.$(".bluesky-reply-error")).not.toExist();
+		await expect(leaf.$(".bluesky-post-btn")).toBeEnabled();
 	});
 
 	it("opens the insert-link modal for selected text and closes on Escape", async function () {

--- a/test/unit/reply.test.ts
+++ b/test/unit/reply.test.ts
@@ -1,11 +1,40 @@
 import assert from 'node:assert/strict'
 import type { AppBskyFeedDefs } from '@atproto/api'
-import { parseBskyPostUrl, deriveReplyRef } from '../../src/utils/reply'
+import {
+  parseBskyPostUrl,
+  deriveReplyRef,
+  resolveReplyTarget,
+  type ReplyResolverAgent,
+} from '../../src/utils/reply'
 
 type PostView = AppBskyFeedDefs.PostView
 
-const makePost = (uri: string, cid: string, record: Record<string, unknown>): PostView =>
-  ({ uri, cid, record } as unknown as PostView)
+const makePost = (
+  uri: string,
+  cid: string,
+  record: Record<string, unknown>,
+  author: { handle: string; displayName?: string } = { handle: 'author.bsky.social', displayName: 'Author' },
+): PostView => ({ uri, cid, record, author } as unknown as PostView)
+
+interface MockAgent extends ReplyResolverAgent {
+  calls: { resolveHandle: string[]; getPosts: string[][] }
+}
+
+const mockAgent = (opts: { did?: string; posts?: PostView[]; getPostsThrows?: boolean }): MockAgent => {
+  const calls = { resolveHandle: [] as string[], getPosts: [] as string[][] }
+  return {
+    calls,
+    async resolveHandle({ handle }) {
+      calls.resolveHandle.push(handle)
+      return { data: { did: opts.did ?? 'did:plc:resolved' } }
+    },
+    async getPosts({ uris }) {
+      calls.getPosts.push(uris)
+      if (opts.getPostsThrows) throw new Error('boom')
+      return { data: { posts: opts.posts ?? [] } }
+    },
+  }
+}
 
 describe('parseBskyPostUrl', () => {
   it('parses a standard post URL with a handle', () => {
@@ -47,5 +76,64 @@ describe('deriveReplyRef', () => {
     const refs = deriveReplyRef(makePost(target.uri, target.cid, { text: 'hi', reply: { root } }))
     assert.deepEqual(refs.parent, target)
     assert.deepEqual(refs.root, root)
+  })
+})
+
+describe('resolveReplyTarget', () => {
+  const url = 'https://bsky.app/profile/author.bsky.social/post/rkey1'
+
+  it('resolves a handle URL to refs and a preview', async () => {
+    const post = makePost('at://did:plc:author/app.bsky.feed.post/rkey1', 'cidTARGET', { text: 'hello world' })
+    const agent = mockAgent({ did: 'did:plc:author', posts: [post] })
+
+    const result = await resolveReplyTarget(agent, url)
+
+    assert.ok(result)
+    assert.equal(agent.calls.resolveHandle[0], 'author.bsky.social')
+    assert.deepEqual(agent.calls.getPosts[0], ['at://did:plc:author/app.bsky.feed.post/rkey1'])
+    assert.deepEqual(result.refs.parent, { uri: post.uri, cid: 'cidTARGET' })
+    assert.deepEqual(result.refs.root, { uri: post.uri, cid: 'cidTARGET' })
+    assert.deepEqual(result.preview, { authorHandle: 'author.bsky.social', authorName: 'Author', text: 'hello world' })
+  })
+
+  it('skips handle resolution when the actor is already a DID', async () => {
+    const didUrl = 'https://bsky.app/profile/did:plc:author/post/rkey1'
+    const post = makePost('at://did:plc:author/app.bsky.feed.post/rkey1', 'cidTARGET', { text: 'hi' })
+    const agent = mockAgent({ posts: [post] })
+
+    const result = await resolveReplyTarget(agent, didUrl)
+
+    assert.ok(result)
+    assert.equal(agent.calls.resolveHandle.length, 0)
+    assert.deepEqual(agent.calls.getPosts[0], ['at://did:plc:author/app.bsky.feed.post/rkey1'])
+  })
+
+  it('returns the external thread root when the target is itself a reply', async () => {
+    const root = { uri: 'at://did:plc:op/app.bsky.feed.post/root1', cid: 'cidROOT' }
+    const post = makePost('at://did:plc:author/app.bsky.feed.post/rkey1', 'cidTARGET', { text: 'reply', reply: { root } })
+    const agent = mockAgent({ did: 'did:plc:author', posts: [post] })
+
+    const result = await resolveReplyTarget(agent, url)
+
+    assert.ok(result)
+    assert.deepEqual(result.refs.root, root)
+    assert.deepEqual(result.refs.parent, { uri: post.uri, cid: 'cidTARGET' })
+  })
+
+  it('returns null when the post is not found', async () => {
+    const agent = mockAgent({ did: 'did:plc:author', posts: [] })
+    assert.equal(await resolveReplyTarget(agent, url), null)
+  })
+
+  it('returns null when a request throws', async () => {
+    const agent = mockAgent({ did: 'did:plc:author', getPostsThrows: true })
+    assert.equal(await resolveReplyTarget(agent, url), null)
+  })
+
+  it('returns null for a malformed URL without calling the agent', async () => {
+    const agent = mockAgent({})
+    assert.equal(await resolveReplyTarget(agent, 'https://example.com/not-a-post'), null)
+    assert.equal(agent.calls.resolveHandle.length, 0)
+    assert.equal(agent.calls.getPosts.length, 0)
   })
 })

--- a/test/unit/reply.test.ts
+++ b/test/unit/reply.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import type { AppBskyFeedDefs } from '@atproto/api'
+import { parseBskyPostUrl, deriveReplyRef } from '../../src/utils/reply'
+
+type PostView = AppBskyFeedDefs.PostView
+
+const makePost = (uri: string, cid: string, record: Record<string, unknown>): PostView =>
+  ({ uri, cid, record } as unknown as PostView)
+
+describe('parseBskyPostUrl', () => {
+  it('parses a standard post URL with a handle', () => {
+    const r = parseBskyPostUrl('https://bsky.app/profile/evanharris.bsky.social/post/3lctfdfa4vk2a')
+    assert.deepEqual(r, { actor: 'evanharris.bsky.social', rkey: '3lctfdfa4vk2a' })
+  })
+
+  it('parses a post URL with a DID actor segment', () => {
+    const r = parseBskyPostUrl('https://bsky.app/profile/did:plc:abc123/post/3lctfdfa4vk2a')
+    assert.deepEqual(r, { actor: 'did:plc:abc123', rkey: '3lctfdfa4vk2a' })
+  })
+
+  it('tolerates a trailing slash and query string', () => {
+    const r = parseBskyPostUrl('https://bsky.app/profile/foo.bsky.social/post/abc123/?ref=x')
+    assert.deepEqual(r, { actor: 'foo.bsky.social', rkey: 'abc123' })
+  })
+
+  it('returns null for a profile URL with no post segment', () => {
+    assert.equal(parseBskyPostUrl('https://bsky.app/profile/foo.bsky.social'), null)
+  })
+
+  it('returns null for non-bsky URLs and empty input', () => {
+    assert.equal(parseBskyPostUrl('https://example.com/post/123'), null)
+    assert.equal(parseBskyPostUrl(''), null)
+  })
+})
+
+describe('deriveReplyRef', () => {
+  const target = { uri: 'at://did:plc:author/app.bsky.feed.post/rkey1', cid: 'cidTARGET' }
+
+  it('uses the target as its own root for a top-level post', () => {
+    const refs = deriveReplyRef(makePost(target.uri, target.cid, { text: 'hi' }))
+    assert.deepEqual(refs.parent, target)
+    assert.deepEqual(refs.root, target)
+  })
+
+  it('uses the existing thread root when the target is itself a reply', () => {
+    const root = { uri: 'at://did:plc:op/app.bsky.feed.post/root1', cid: 'cidROOT' }
+    const refs = deriveReplyRef(makePost(target.uri, target.cid, { text: 'hi', reply: { root } }))
+    assert.deepEqual(refs.parent, target)
+    assert.deepEqual(refs.root, root)
+  })
+})

--- a/test/unit/tsconfig.json
+++ b/test/unit/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node", "mocha"]
+  },
+  "include": ["**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Adds the ability to reply to an already-published Bluesky post from the compose tab. Paste a `bsky.app` post URL into the new **Reply to a Bluesky post** field, confirm the previewed target, and your post (or whole thread) is published as a reply that continues that post's thread. Works for any public post.

Closes #15.

Plan: `docs/plans/2026-06-22-001-feat-reply-to-existing-posts-plan.md`.

## What changed

- **Resolution logic** (`src/utils/reply.ts`, obsidian-free + unit-tested): `parseBskyPostUrl` (handle or DID, tolerant of trailing slash/query), `deriveReplyRef` (the thread-root rule: `root = target.record.reply?.root ?? target`), and `resolveReplyTarget(agent, url)` against an injected agent.
- **`BlueskyBot`** (`src/bluesky.ts`): a `resolveReplyTarget` wrapper (resolve unauthenticated, log in and retry once), and an optional reply-refs argument on `createPost`/`createThread`. The thread loop is seeded from the reply refs so the first post replies to the target and the external thread root stays constant for the whole thread; non-reply posting is unchanged.
- **Compose UI** (`src/views/BlueskyTab.ts`, `styles.css`): the optional reply field, a target preview (author + snippet) with a remove button, Post-button gating while a URL is unresolved/invalid, and reply-state reset on success. A request-sequence guard prevents an out-of-order lookup from attaching the post to the wrong thread.
- **Test lane** (`.mocharc.json`, `package.json`, `test/unit/`): a network-free mocha + tsx unit lane (type-checked) alongside the existing provider-free wdio e2e suite.
- **Docs** (`README.md`, `test/README.md`): a "Reply to a post" usage section, the reply-target lookup added to the network-use disclosure, and the unit lane documented.

## Testing

- `npm run test:unit` — 13 passing (URL parsing, root derivation, `resolveReplyTarget` against a mock agent: handle vs DID, reply-vs-top-level root, not-found, throw, malformed URL).
- `npm run test:e2e` — 19 passing, including 3 new reply-field specs (renders, invalid-URL error + Post gating, clearing re-enables Post).
- `npm run build` and `npm run lint` clean.

## Known residuals

The e2e suite is provider-free by design, so these are not covered by automated tests (the pure root-derivation logic *is* unit-tested):

- `BlueskyBot.resolveReplyTarget` login-retry wrapper (obsidian-coupled).
- `createPost`/`createThread` reply attachment and the constant-root thread invariant (obsidian-coupled; verified manually).
- The network success path in the UI (preview render, remove button).

A future fake-PDS / XRPC stub (already noted as a follow-up in `test/README.md`) would close these.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a client-side Obsidian plugin with no server component. Manual validation: paste a real `bsky.app` post URL, confirm the preview, and verify the reply threads correctly on Bluesky (single reply and a multi-post thread, against both a top-level post and a nested reply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
